### PR TITLE
Use url::form_urlencoded::Serializer to build forms

### DIFF
--- a/src/app/listings.rs
+++ b/src/app/listings.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use failure::Error;
 use hyper::{Body, Request};
 use json::Value;
-use url::Url;
+use url::{form_urlencoded, Url};
 
 use data::{Comment, Comments, Listing, Post, Thing};
-use net::{body_from_map, uri_params_from_map};
+use net::uri_params_from_map;
 use {App, Sort};
 
 impl App {
@@ -90,10 +90,9 @@ impl App {
 	pub fn get_comment_tree(&self, post: &str) -> Result<Listing<Comment>, Error> {
 		// TODO add sorting and shit
 
-		let mut params: HashMap<&str, &str> = HashMap::new();
-		params.insert("limit", "2147483648");
-		params.insert("depth", "2147483648");
-		let req = Request::get(format!("https://www.reddit.com/comments/{}/.json", post)).body(body_from_map(&params)).unwrap();
+		let max_int = "2147483648";
+		let body = form_urlencoded::Serializer::new(String::new()).append_pair("limit", max_int).append_pair("depth", max_int).finish();
+		let req = Request::get(format!("https://www.reddit.com/comments/{}/.json", post)).body(body.into()).unwrap();
 
 		let data = self.conn.run_request(req)?;
 		let data = data[1]["data"]["children"].clone();

--- a/src/app/messages.rs
+++ b/src/app/messages.rs
@@ -1,10 +1,7 @@
-use std::collections::HashMap;
-
 use failure::Error;
 use hyper::Request;
 use url::form_urlencoded;
 
-use net::body_from_map;
 use App;
 
 impl App {
@@ -14,14 +11,9 @@ impl App {
 	/// * `subject` - Subject of the message
 	/// * `body` - Body of the message
 	pub fn message(&self, to: &str, subject: &str, body: &str) -> Result<(), Error> {
-		let subject: String = form_urlencoded::byte_serialize(subject.as_bytes()).collect();
-		let body: String = form_urlencoded::byte_serialize(body.as_bytes()).collect();
-		let mut params: HashMap<&str, &str> = HashMap::new();
-		params.insert("to", to);
-		params.insert("subject", &subject);
-		params.insert("text", &body);
+		let form = form_urlencoded::Serializer::new(String::new()).append_pair("to", to).append_pair("subject", subject).append_pair("text", body).finish();
 
-		let req = Request::post("https://oauth.reddit.com/api/compose/.json").body(body_from_map(&params)).unwrap();
+		let req = Request::post("https://oauth.reddit.com/api/compose/.json").body(form.into()).unwrap();
 
 		match self.conn.run_auth_request(req) {
 			Ok(_) => Ok(()),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -226,20 +226,6 @@ impl Connection {
 	}
 }
 
-/// Creates a HTTP/hyper Body from a hashmap, in urlencoded form.
-pub fn body_from_map<S: BuildHasher>(map: &HashMap<&str, &str, S>) -> Body {
-	let mut body_str = String::new();
-
-	for (i, item) in map.iter().enumerate() {
-		// Push the paramater to the body with an & at the end unless it's the last parameter
-		body_str.push_str(&format!("{}={}{}", item.0, item.1, if i < map.len() - 1 { "&" } else { "" }));
-	}
-
-	trace!("Setup body: \n{}\n", body_str);
-
-	Body::from(body_str)
-}
-
 /// Creates a url with encoded parameters from hashmap. Right now it's kinda hacky
 pub fn uri_params_from_map<S: BuildHasher>(url: &str, map: &HashMap<&str, &str, S>) -> Result<Uri, Error> {
 	use url::Url;


### PR DESCRIPTION
The previous method required manually specifying when fields needed to
be urlencoded. This ended up in mistakes (e.g. passwords weren't
urlencoded).

As a bonus, this new method avoids some intermediate copies and
hashtable construction (and associated heap allocations), so it should
be more performant.